### PR TITLE
Fix missing whatsnew from sitemap and ditch pagination v2 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,13 +28,7 @@ collections:
 
 plugins:
   - github-pages
-  - jekyll-paginate-v2
   - jekyll-sitemap
-
-pagination:
-
-  # Site-wide kill switch, disabled here it doesn't run at all
-  enabled: true
 
 # https://github.com/helaili/jekyll-action/issues/43
 exclude:

--- a/_includes/footer-section.html
+++ b/_includes/footer-section.html
@@ -86,7 +86,7 @@
                         <a href="/support" class="border-b border-solid border-transparent hover:border-blue-800 hover:text-blue-800">Support</a>
                     </li>
                     <li class="mb-2">
-                        <a href="/whatsnew/" class="border-b border-solid border-transparent hover:border-blue-800 hover:text-blue-800">What's New</a>
+                        <a href="/whatsnew" class="border-b border-solid border-transparent hover:border-blue-800 hover:text-blue-800">What's New</a>
                     </li>
                     <li class="mb-2">
                         <a href="/#contact" class="border-b border-solid border-transparent hover:border-blue-800 hover:text-blue-800">Contact Us</a>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -12,7 +12,7 @@
 
         <div class="navbar-collapse collapse" id="account-navigation">
             <ul class="nav navbar-nav main-navigation pt-1">
-                <li class="{% if page.slug == "whatsnew"%}active{% endif %}"><a class="nav-link" href="{{site.content_url}}/whatsnew/">What's New</a></li>
+                <li class="{% if page.slug == "whatsnew"%}active{% endif %}"><a class="nav-link" href="{{site.content_url}}/whatsnew">What's New</a></li>
                 <li><a class="nav-link" href="https://docs.servicestack.net">Docs</a></li>
                 <li><a class="nav-link" href="https://forums.servicestack.net">Forums</a></li>
                 <li class="{% if page.slug == "download"%}active{% endif %}"><a class="nav-link" href="/download">Download</a></li>

--- a/_pages/blog.html
+++ b/_pages/blog.html
@@ -2,12 +2,6 @@
 title: Blog
 slug: blog
 sitemap: false
-pagination:
-  enabled: true
-  collection: blog
-  sort_reverse: true
-  per_page: 10
-  permalink: '/page/:num/'
 ---
 <style>
     .news-post-date {
@@ -17,11 +11,12 @@ pagination:
 </style>
 <div class="container news-container">
     <h1 style="text-align: center">{{page.title}}</h1>
-    {% for item in paginator.posts %}
+    {% assign sorted = site.blog | reverse %}
+    {% for item in sorted %}
     {% if item.draft == true %}
-      {% if site.show_drafts == nil or site.show_drafts == false %}
-        {% continue %}
-      {% endif %}
+    {% if site.show_drafts == nil or site.show_drafts == false %}
+    {% continue %}
+    {% endif %}
     {% endif %}
 
     <div class="grid grid-cols-12 mt-8">
@@ -45,27 +40,7 @@ pagination:
     </div>
     {% endfor %}
 
-    <!-- PAGINATION -->
-    {% if paginator.total_pages > 1 %}
-    <div class="row">
-        <div class="col-sm-12 text-center m-t-40 m-b-40">
-            <div class="pagination font-alt">
-                {% if paginator.previous_page %}
-                <span><a href="{{ paginator.previous_page_path | prepend: site.baseurl }}"><i class="fa fa-angle-left"></i></a></span>
-                {% endif %}
-                {% if paginator.page_trail %}
-                {% for trail in paginator.page_trail %}
-                <span {% if page.url == trail.path %}class="active"{% endif %}>
-                    <a href="{{ trail.path | prepend: site.baseurl | remove: 'index.html' }}" title="{{trail.title}}">{{ trail.num }}</a>
-                </span>
-                {% endfor %}
-                {% endif %}
-                {% if paginator.next_page %}
-                <span><a href="{{ paginator.next_page_path | prepend: site.baseurl }}"><i class="fa fa-angle-right"></i></a></span>
-                {% endif %}
-            </div>
-        </div>
-    </div>
-    {% endif %}
+    <!-- PAGINATION when needed -->
+
     <!-- /PAGINATION -->
 </div>

--- a/_pages/whatsnew.html
+++ b/_pages/whatsnew.html
@@ -1,12 +1,6 @@
 ---
 title: What's new
 slug: whatsnew
-pagination:
-  enabled: true
-  collection: whatsnew
-  sort_reverse: true
-  per_page: 15
-  permalink: '/page/:num/'
 ---
 <style>
     .whatsnew-container ul>li {
@@ -23,7 +17,8 @@ pagination:
     <h1 class="text-center my-4 pt-8">Latest features &amp; highlights</h1>
     <div class="colored-line"></div>
 
-    {% for item in paginator.posts %}
+    {% assign sorted = site.whatsnew | reverse %}
+    {% for item in sorted %}
     {% assign contentSplit = item.content | split: site.content_separator %}
     {% assign contentSize = contentSplit | size %}
     {% assign featureSize = item.feature_url | size %}
@@ -35,9 +30,9 @@ pagination:
             <h2 class="mt-8 text-center text-7xl font-normal">{{ item.title }}</h2>
             <div class="text-center text-lg font-normal text-gray-500 mb-8">{{ item.date | date: '%B %d, %Y' }}</div>
         </div>
-    {% for i in (0..2) %}
+        {% for i in (0..2) %}
         {% if i >= contentSize or i >= featureSize or i >= previewSize or i >= subtitleSize %}
-           {% break %}
+        {% break %}
         {% else %}
         <div class="mt- flex flex-wrap my-20">
             <div class="w-full sm:w-1/2 wow fadeInRight animated px-4 whatsnew-container-item-img" data-wow-offset="10" data-wow-duration="1.5s">
@@ -61,7 +56,7 @@ pagination:
             </div>
         </div>
         {% endif %}
-    {% endfor %}
+        {% endfor %}
 
 
     </div>
@@ -69,27 +64,7 @@ pagination:
 
     {% endfor %}
 
-    <!-- PAGINATION -->
-    {% if paginator.total_pages > 1 %}
-    <div class="row">
-        <div class="col-sm-12 text-center m-t-40 m-b-40">
-            <div class="pagination font-alt">
-                {% if paginator.previous_page %}
-                <span><a href="{{ paginator.previous_page_path | prepend: site.baseurl }}"><i class="fa fa-angle-left"></i></a></span>
-                {% endif %}
-                {% if paginator.page_trail %}
-                {% for trail in paginator.page_trail %}
-                <span {% if page.url == trail.path %}class="active"{% endif %}>
-                    <a href="{{ trail.path | prepend: site.baseurl | remove: 'index.html' }}" title="{{trail.title}}">{{ trail.num }}</a>
-                </span>
-                {% endfor %}
-                {% endif %}
-                {% if paginator.next_page %}
-                <span><a href="{{ paginator.next_page_path | prepend: site.baseurl }}"><i class="fa fa-angle-right"></i></a></span>
-                {% endif %}
-            </div>
-        </div>
-    </div>
-    {% endif %}
+    <!-- PAGINATION when needed -->
+
     <!-- /PAGINATION -->
 </div>


### PR DESCRIPTION
Fix missing whatsnew from sitemap and ditch pagination v2 for standard collections.

Whats new now a page rather than a directory, same with blog.

Since they are both collections, created as PR incase you wanted to keep as `whatsnew/` rather than clean page like you've done for the rest. There is a whatsnew/ prefix due to posts being created there but since S3 is object store, I think should still work and resolve the .html of the new `whatsnew` page.